### PR TITLE
Fixed C++11 build error

### DIFF
--- a/version3/compile_linux_gcc.sh
+++ b/version3/compile_linux_gcc.sh
@@ -1,7 +1,7 @@
 mkdir "binaries-linux" #
 #
 basepath="binaries-linux/" #
-flags="-O2 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive" #
+flags="-O2 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++11" #
 #
 g++ Source/*.cpp -o "${basepath}2006-Core2"           $flags -march=core2          -D "x64_2006_Core2" #
 g++ Source/*.cpp -o "${basepath}2011-SandyBridge"     $flags -march=sandybridge    -D "x64_2011_SandyBridge" #


### PR DESCRIPTION
This PR fixes compile errors for version 3 using gcc 5.4.0 20160609, where C++11 is not the default.